### PR TITLE
lcd4linux: Add python3-zoneinfo as dependency

### DIFF
--- a/lcd4linux/CONTROL/control
+++ b/lcd4linux/CONTROL/control
@@ -3,4 +3,4 @@ Version: 5.0-r9
 Description: LCD4linux plugin
 Maintainer: OpenPLi team <forum@openpli.org>
 Homepage: http://www.openpli.org
-Depends: python3-codecs, python3-ctypes, python3-datetime, python3-email, python3-icalendar, python3-image, python3-mutagen, python3-pyusb, python3-shell, python3-simplejson, python3-pillow, python3-requests, png-util, pydpflib
+Depends: python3-codecs, python3-ctypes, python3-datetime, python3-email, python3-icalendar, python3-image, python3-mutagen, python3-pyusb, python3-shell, python3-simplejson, python3-pillow, python3-requests, python3-zoneinfo, png-util, pydpflib


### PR DESCRIPTION
Plugin  Extensions/LCD4linux failed to load: No module named 'backports' Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/icalendar/timezone/zoneinfo.py", line 8, in <module>
ModuleNotFoundError: No module named 'zoneinfo'