### PR TITLE
networkbrowser: Fix build with gcc 15

### DIFF
--- a/networkbrowser/src/lib/main.c
+++ b/networkbrowser/src/lib/main.c
@@ -29,6 +29,8 @@
 
 static PyObject *error;
 
+int showNfsShare(char *pythonIp, nfsinfo *nfsInfo);
+
 PyObject *_netzInfo(PyObject *self, PyObject *args)
 {
 	netinfo *nInfo;


### PR DESCRIPTION
 main.c: In function '_nfsShare':
| main.c:95:15: error: implicit declaration of function 'showNfsShare'; did you mean '_nfsShare'? [-Wimplicit-function-declaration]
|    95 |         err = showNfsShare(s, nfsInfo);
|       |               ^~~~~~~~~~~~
|       |               _nfsShare